### PR TITLE
Added inofficial autodiscovery to the my-PV integration

### DIFF
--- a/custom_components/mypv/__init__.py
+++ b/custom_components/mypv/__init__.py
@@ -67,3 +67,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     return True
 
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry"""
+    return await hass.config_entries.async_unload_platforms(entry, ["sensor", "switch", "button"])

--- a/custom_components/mypv/config_flow.py
+++ b/custom_components/mypv/config_flow.py
@@ -44,7 +44,6 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._host = None
         self._filtered_sensor_types = {}
         self._devices = {}
-        self._config_method = None
 
     def _host_in_configuration_exists(self, host) -> bool:
         """Return True if host exists in configuration."""
@@ -106,7 +105,6 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._errors[CONF_HOST] = "invalid_ip"
 
         user_input = user_input or {CONF_HOST: "192.168.0.0"}
-        self._config_method = "ip_known"
 
         ip_known_schema = vol.Schema(
             {vol.Required(CONF_HOST, default="192.168.0.0"): str}
@@ -130,8 +128,6 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 errors["base"] = "invalid_subnet"
             
-        self._config_method = "ip_unknown"
-
         ip_unknown_schema = vol.Schema(
             {vol.Required("subnet", default="192.168.0"): str}
         )
@@ -210,9 +206,7 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_sensors(self, user_input=None):
         """Handle the sensor selection step."""
-        if user_input is not None:
-            if self._config_method is "ip_known":
-                
+        if user_input is not None:                
             return self.async_create_entry(
                 title=f"{self._devices[self._host]}",
                 data={

--- a/custom_components/mypv/config_flow.py
+++ b/custom_components/mypv/config_flow.py
@@ -121,10 +121,10 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     
     async def async_step_ip_known(self, user_input=None):
         if user_input is not None:
-            host = user_input[CONF_HOST]
-            if self.is_valid_ip(host):
-                if await self.check_ip_device(host):
-                    if not self._host_in_configuration_exists(host):
+            self._host = user_input[CONF_HOST]
+            if self.is_valid_ip(self._host):
+                if await self.check_ip_device(self._host):
+                    if not self._host_in_configuration_exists(self._host):
                         await self.hass.async_add_executor_job(self._get_sensor, self._host)
                         return await self.async_step_sensors()
                     else:

--- a/custom_components/mypv/config_flow.py
+++ b/custom_components/mypv/config_flow.py
@@ -56,7 +56,7 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 timeout = ClientTimeout(total=5)
                 async with session.get(f"http://{host}/data.jsn", timeout=timeout) as response:
                     if response.status == 200:
-                        data = response.json()
+                        data = await response.json()
                         json_keys = set(data.keys())
                         self._filtered_sensor_types = {}
 
@@ -66,6 +66,9 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         
                         if not self._filtered_sensor_types:
                             _LOGGER.warning("No matching sensors found on the device.")
+                    else:
+                        self._filtered_sensor_types = {}
+                        _LOGGER.error(f"Can't connect to {host}: Bad HTTP Request status")
 
             except aiohttp.ClientError as e:
                 _LOGGER.error(f"Failed to connect to {host}: {e}")

--- a/custom_components/mypv/config_flow.py
+++ b/custom_components/mypv/config_flow.py
@@ -44,6 +44,7 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._host = None
         self._filtered_sensor_types = {}
         self._devices = {}
+        self._config_method = None
 
     def _host_in_configuration_exists(self, host) -> bool:
         """Return True if host exists in configuration."""
@@ -91,8 +92,10 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._host = user_input[CONF_HOST]
             if self.is_valid_ip(self._host):
-                if await self.check_ip_device(self._host):
+                device = await self.check_ip_device(self._host)
+                if device:
                     if not self._host_in_configuration_exists(self._host):
+                        self._devices[self._host] = f"{device} ({self._host})"
                         await self._get_sensor(self._host)
                         return await self.async_step_sensors()
                     else:
@@ -103,6 +106,7 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._errors[CONF_HOST] = "invalid_ip"
 
         user_input = user_input or {CONF_HOST: "192.168.0.0"}
+        self._config_method = "ip_known"
 
         ip_known_schema = vol.Schema(
             {vol.Required(CONF_HOST, default="192.168.0.0"): str}
@@ -126,6 +130,8 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 errors["base"] = "invalid_subnet"
             
+        self._config_method = "ip_unknown"
+
         ip_unknown_schema = vol.Schema(
             {vol.Required("subnet", default="192.168.0"): str}
         )
@@ -205,6 +211,8 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_sensors(self, user_input=None):
         """Handle the sensor selection step."""
         if user_input is not None:
+            if self._config_method is "ip_known":
+                
             return self.async_create_entry(
                 title=f"{self._devices[self._host]}",
                 data={

--- a/custom_components/mypv/config_flow.py
+++ b/custom_components/mypv/config_flow.py
@@ -208,6 +208,10 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
+        if not self._filtered_sensor_types:
+            self._errors["base"] = "no_sensors_found"
+            return await self.async_step_ip_known()
+        
         default_monitored_conditions = (
             [] if self._async_current_entries() else DEFAULT_MONITORED_CONDITIONS
         )

--- a/custom_components/mypv/config_flow.py
+++ b/custom_components/mypv/config_flow.py
@@ -238,7 +238,7 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the sensor selection step."""
         if user_input is not None:
             return self.async_create_entry(
-                title=f"{self._info['device']} - {self._info['number']}",
+                title=f"{self._devices[self._host]}",
                 data={
                     CONF_HOST: self._host,
                     CONF_MONITORED_CONDITIONS: user_input[CONF_MONITORED_CONDITIONS],

--- a/custom_components/mypv/config_flow.py
+++ b/custom_components/mypv/config_flow.py
@@ -6,7 +6,7 @@ import ipaddress
 import aiohttp
 import asyncio
 from requests.exceptions import RequestException
-from asyncio import ClientTimeout
+from aiohttp import ClientTimeout
 
 from homeassistant import config_entries
 import homeassistant.helpers.config_validation as cv

--- a/custom_components/mypv/config_flow.py
+++ b/custom_components/mypv/config_flow.py
@@ -2,8 +2,11 @@
 import logging
 import voluptuous as vol
 import requests
-import json
-from requests.exceptions import HTTPError, ConnectTimeout, RequestException
+import ipaddress
+import aiohttp
+import asyncio
+from requests.exceptions import RequestException
+from asyncio import ClientTimeout
 
 from homeassistant import config_entries
 import homeassistant.helpers.config_validation as cv
@@ -41,13 +44,14 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._info = {}
         self._host = None
         self._filtered_sensor_types = {}
+        self._devices = {}
 
     def _host_in_configuration_exists(self, host) -> bool:
         """Return True if site_id exists in configuration."""
         return host in mypv_entries(self.hass)
-
+    """
     def _check_host(self, host) -> bool:
-        """Check if we can connect to the mypv."""
+        Check if we can connect to the mypv.
         try:
             response = requests.get(f"http://{host}/mypv_dev.jsn", timeout=10)
             response.raise_for_status()
@@ -61,7 +65,7 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.error(f"Unexpected error: {e}")
             return False
         return True
-    
+    """
     def _get_sensor(self, host):
         """Fetch sensor data and update _filtered_sensor_types."""
         try:
@@ -80,9 +84,9 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except RequestException as e:
             _LOGGER.error(f"Error fetching sensor data: {e}")
             self._filtered_sensor_types = {}
-
+    """
     async def async_step_user(self, user_input=None):
-        """Handle the initial step."""
+            Handle the initial step.
         if user_input is not None:
             self._host = user_input[CONF_HOST]
             if self._host_in_configuration_exists(self._host):
@@ -104,6 +108,131 @@ class MypvConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=setup_schema, errors=self._errors
         )
+"""
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options={
+                "ip_known": "IP address",
+                "ip_unknown": "IP subnet scan"
+            },
+        )  
+    
+    async def async_step_ip_known(self, user_input=None):
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            if self.is_valid_ip(host):
+                if await self.check_ip_device(host):
+                    if not self._host_in_configuration_exists(host):
+                        await self.hass.async_add_executor_job(self._get_sensor, self._host)
+                        return await self.async_step_sensors()
+                    else:
+                        self._errors[CONF_HOST] = "host_already_configured"
+                else:
+                    self._errors[CONF_HOST] = "could_not_connect"
+            else:
+                self._errors[CONF_HOST] = "invalid_ip"
+
+        user_input = user_input or {CONF_HOST: "192.168.0.0"}
+
+        ip_known_schema = vol.Schema(
+            {vol.Required(CONF_HOST, default="192.168.0.0"):str}
+        )
+        return self.async_show_form(
+            step_id="ip_known",
+            data_schema=ip_known_schema,
+            errors=self._errors
+        )
+    
+    async def async_step_ip_unknown(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            subnet = user_input["subnet"]
+            if self.is_valid_subnet(subnet):
+                self._devices = await self.scan_devices(subnet)
+                if self._devices:    
+                    return await self.async_step_select_device()
+                else:
+                    errors["base"] = "no_devices_found"
+            else:
+                errors["base"] = "invalid_subnet"
+            
+        ip_unknown_schema = vol.Schema(
+            {vol.Required("subnet", default="192.168.0"):str}
+        )
+
+        return self.async_show_form(
+            step_id="ip_unknown",
+            data_schema=ip_unknown_schema,
+            errors=errors
+        )  
+    
+    async def async_step_select_device(self, user_input=None):
+        if user_input is not None:
+            self._host = user_input["device"]
+            await self.hass.async_add_executor_job(self._get_sensor, self._host)
+            return await self.async_step_sensors()        
+        
+        select_device_schema = vol.Schema({
+                vol.Required("device"): vol.In(list(self._devices.values()))
+            })
+        
+        return self.async_show_form(
+            step_id="select_device",
+            data_schema=select_device_schema,
+            description_placeholders={"devices": ", ".join(self._devices.values())}
+        )  
+        
+    def is_valid_ip(self, ip):
+        try:
+            ipaddress.ip_address(ip)
+            return True
+        except ValueError:
+            _LOGGER.error("You entered an invalid IP")
+            return False
+    
+    def is_valid_subnet(self, subnet):
+        cntPeriod = subnet.count('.')
+        if cntPeriod != 2:
+            _LOGGER.error("Invalid subnet")
+            return False
+        ip = subnet + ".0"
+        return self.is_valid_ip(ip)
+        
+    async def check_ip_device(self, ip):
+        async with aiohttp.ClientSession() as session:
+            return await self.check_device(session, ip)
+    
+    async def scan_devices(self, subnet):
+        devices = {}
+        async with aiohttp.ClientSession() as session:
+            tasks = []
+            for i in range(1, 255):
+                ip = f"{subnet}.{i}"
+                tasks.append(self.check_device(session, ip))
+
+            results = await asyncio.gather(*tasks)
+
+            for ip, device_name in zip([f"{subnet}.{i}" for i in range(1, 255)], results):
+                if (device_name is not None) and (not self._host_in_configuration_exists(ip)):
+                    devices[ip] = f"{device_name} {ip}"
+
+        return devices
+    
+    async def check_device(self, session, ip):
+        try:
+            timeout = ClientTimeout(total=15)
+            async with session.get(f"http://{ip}/mypv_dev.jsn", timeout=timeout) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    return data.get("device")
+                else:
+                    return None
+        except aiohttp.ClientError as e:
+            return None
+        except asyncio.TimeoutError as e:
+            return None
 
     async def async_step_sensors(self, user_input=None):
         """Handle the sensor selection step."""

--- a/custom_components/mypv/strings.json
+++ b/custom_components/mypv/strings.json
@@ -1,5 +1,5 @@
 {
-  "title": "MYPV",
+  "title": "my-PV",
   "config": {
     "step": {
       "user": {


### PR DESCRIPTION
That repository has built in inofficial autodiscovery because usually my-PV devices do not support mDNS, MQTT, etc. So, in the config_flow you can choose whether you type in the ip address of your device manually or you scan for my-PV devices by entering a subnet (Like in the my-PV cloud). After the scan a list of my-PV devices which are NOT configured yet appears and can be configured. After selecting your device you can choose the sensors you want to display. 